### PR TITLE
Remove `self` from download_dataset staticmethod.

### DIFF
--- a/src/lablet_generalization_benchmark/load_dataset.py
+++ b/src/lablet_generalization_benchmark/load_dataset.py
@@ -92,7 +92,7 @@ class BenchmarkDataset(torch.utils.data.Dataset):
         return image, targets
 
     @staticmethod
-    def download_dataset(self, file_path):
+    def download_dataset(file_path):
         os.makedirs(os.path.dirname(file_path), exist_ok=True)
         from urllib import request
         if 'dsprites' in file_path.lower():


### PR DESCRIPTION
Staticmethods don't receive the `self` argument. When trying to download a dataset this happens:

```python
File "./InDomainGeneralizationBenchmark/src/lablet_generalization_benchmark/load_dataset.py", line 63, in load_data
    self.download_dataset(filename)
TypeError: download_dataset() missing 1 required positional argument: 'file_path'
```